### PR TITLE
main.qml: fix 'Parameter "mouse" is not declared' warnings

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -11,19 +11,19 @@ Window {
     MouseArea {
         id: mouseArea
         anchors.fill: parent
-        onPressed: {
+        onPressed: (mouse) => {
             target.x = mouse.x
             target.y = mouse.y
             console.log("Released at ", mouse.x, ";", mouse.y)
         }
 
-        onReleased: {
+        onReleased: (mouse) => {
             target.x = mouse.x
             target.y = mouse.y
             console.log("Pressed at  ", mouse.x, ";", mouse.y)
         }
 
-        onClicked: {
+        onClicked: (mouse) => {
             console.log("Clicked at  ", mouse.x, ";", mouse.y)
         }
     }


### PR DESCRIPTION
On first running, the three event handlers for MouseArea cause this warning. The full text is:

> Parameter "mouse" is not declared. Injection of parameters into signal handlers is
> deprecated. Use JavaScript functions with formal parameters instead.